### PR TITLE
Trim any potential `app.env` value of any leading or trailing whitespace

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -94,7 +94,7 @@ App.bootstrap = function (app, root) {
   app.preboot(builtins.routers);
 
   app.after('config', function (instance, options, done) {
-    app.env = app.env || app.config.get('env') || process.env.NODE_ENV;
+    app.env = (app.env || app.config.get('env') || process.env.NODE_ENV).trim();
     done();
   });
 

--- a/test/slay.test.js
+++ b/test/slay.test.js
@@ -36,7 +36,7 @@ describe('Slay test suite (unit tests)', function () {
       var baseUri = 'http://localhost:8080';
 
       var previous = process.env.NODE_ENV;
-      process.env.NODE_ENV = 'unique-key';
+      process.env.NODE_ENV = 'unique-key ';
 
       /* Boot the app in a before hook */
       before(function (done) {
@@ -70,7 +70,7 @@ describe('Slay test suite (unit tests)', function () {
         });
       });
 
-      it('should set app.env', function (done) {
+      it('should set app.env, trimming any whitespace', function (done) {
         assert.equal(app.env, 'unique-key');
         process.env.NODE_ENV = previous;
         done();


### PR DESCRIPTION
This can occur more commonly on Windows, but anytime this typo occurred a number of bad side-effects followed:

``` sh
# Notice the trailing space after production
NODE_ENV='production ' node my-app.js
```