### PR TITLE
Graceful shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The `App` exposed by `slay` has all of the functionality exposed by an `app` cre
 | `app.preboot`   | Schedule a preboot                      | `broadway`        |
 | `app.mixin`     | Add functionality into the app          | `broadway`        |
 | `app.start`     | Start the application                   | `broadway`        |
-| `app.close`     | Shutdown the application                | `broadway`        |
+| `app.close`     | Gracefully shutdown the application     | `slay.App`        |
 | `app.perform`   | Execute a named interceptor             | `understudy`      |
 | `app.before`    | Execute _before_ a named interceptor    | `understudy`      |
 | `app.after`     | Execute _after_ a named interceptor     | `understudy`      |

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ The `App` exposed by `slay` has all of the functionality exposed by an `app` cre
 | `start`   | Main application startup                | `slay`     |
 | `routers` | Definition of `app.routes`              | `slay`     |
 | `actions` | Critical path application functionality | User       |
+| `close`   | Notification to stop accepting requests | `slay`     |
+| `free`    | Notification to free any held resources | `slay`     |
 
 ### Stacks
 
@@ -199,6 +201,17 @@ All `Stack` instances created by invoking `app.stack` will be exposed on the `ap
 7. The `callback` from `app.start([options], callback);` is invoked. The `app` is now started and ready for use.
 
 ![](assets/flows.png)
+
+### App shutdown in-detail
+
+1. App is told to begin gracefully shutdown and `app.dispose(callback);` is invoked.
+2. `app.perform('close')` performs `before` _"setup"_ interceptors (see: [understudy interceptors]). This executes the built-in `slay` actions of which:
+  - **Calls* `app.close`
+  - Users should stop accepting new requests from any servers they control outside of `slay`.
+3. Any `after` _"setup"_ interceptors are invoked. (see: [understudy interceptors]). _`slay` runs nothing by default here._
+4. `app.perform('free')` performs `before` _"setup"_ interceptors (see: [understudy interceptors]). _`slay` runs nothing by default here._. 
+  - Users should free any resources they hold at this point. This includes examples of timers, database connections, and child processes.
+5. Any `after` _"setup"_ interceptors are invoked. (see: [understudy interceptors]). _`slay` runs nothing by default here._
 
 ## Tests
 

--- a/example/bin/server
+++ b/example/bin/server
@@ -4,21 +4,31 @@
 // Example Slay application
 const app = require('../lib/');
 
-process.on('SIGTERM', function () {
-  app.dispose(function (e) {
-    if (e) {
-      console.error(e);
-      process.exit(1);
-    } else {
-      process.exit(0)
-    }
-  });
-});
-
 app.start({
+  config: {
+    close: {
+      freeAfter: 1,
+      killAfter: 30
+    }
+  },
   http: 0
 }, function listen(error, app) {
-  if (error) return app.log.error(error.message);
+  if (error) {
+    app.log.error(error.message);
+    process.exit(1);
+  }
+
+  process.on('SIGTERM', function () {
+    app.close(function (e) {
+      if (e) {
+        console.error(e);
+        process.exit(1);
+      } else {
+        process.exit(0)
+      }
+    });
+  });
+
   const address = app.servers.http.address();
   app.log.info('App started on %d', address.port);
   app.log.info(`Open http://127.0.0.1:${address.port}/ in a browser.`);

--- a/example/bin/server
+++ b/example/bin/server
@@ -1,10 +1,14 @@
 #!/usr/bin/env node
 'use strict';
 
-require('../lib/').start({
+// Example Slay application
+const app = require('../lib/');
+
+app.start({
   http: 0
 }, function listen(error, app) {
   if (error) return app.log.error(error.message);
   const address = app.servers.http.address();
   app.log.info('App started on %d', address.port);
+  app.log.info(`Open http://127.0.0.1:${address.port}/ in a browser.`);
 });

--- a/example/bin/server
+++ b/example/bin/server
@@ -4,6 +4,17 @@
 // Example Slay application
 const app = require('../lib/');
 
+process.on('SIGTERM', function () {
+  app.dispose(function (e) {
+    if (e) {
+      console.error(e);
+      process.exit(1);
+    } else {
+      process.exit(0)
+    }
+  });
+});
+
 app.start({
   http: 0
 }, function listen(error, app) {

--- a/example/lib/middlewares.js
+++ b/example/lib/middlewares.js
@@ -8,6 +8,7 @@ module.exports = function middlwares(app, options, callback) {
       app.log.info('%s - request - %s', req.method, req.url, {
         rid: ++rid
       });
+      next();
     });
 
     app.after('actions', function postRouting(cb) {

--- a/example/lib/preboots/config.js
+++ b/example/lib/preboots/config.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = function preboots(app, options, callback) {
+  app.config.use('argv')
+            .use('env')
+
+  callback();
+};

--- a/example/lib/preboots/index.js
+++ b/example/lib/preboots/index.js
@@ -4,6 +4,7 @@ const winston = require('winston');
 
 module.exports = function preboots(app, options, callback) {
   app.log.add(winston.transports.Console);
+  app.preboot(require('./config'));
   app.preboot(require('./db'));
 
   callback();

--- a/example/package.json
+++ b/example/package.json
@@ -1,10 +1,14 @@
 {
   "name": "slay-example",
   "version": "1.0.0",
-  "description": "",
+  "description": "An example Slay application",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "node bin/server",
+    "test": "echo \"Example app does not provide tests. Use `npm start`\" && exit 1"
+  },
+  "bin": {
+    "server": "bin/server"
   },
   "author": "",
   "license": "ISC",

--- a/lib/app.js
+++ b/lib/app.js
@@ -111,6 +111,51 @@ App.bootstrap = function (app, root) {
       done.apply(null, arguments);
     });
   });
+
+  app.after('start', function setupGracefulShutdown(instance, options, next) {
+    var shutdown = app.config.get('shutdown');
+    if (shutdown) {
+      console.log(shutdown)
+      var freeAfter = shutdown.freeAfter || 30;
+      // TCP default timeout is 180s
+      var killAfter = shutdown.killAfter || 180;
+      process.on('SIGTERM', function stopListening() {
+        debug('shutdown starting, will free after %d s and force kill after %d s', freeAfter, killAfter);
+        app.perform('close', function stopAccepting(next) {
+          app.close(function closed(err) {
+            if (err) {
+              debug('close error %s', err.message);
+              process.exit(1);
+            }
+            setTimeout(function freeResources() {
+              app.free(function (err) {
+                if (err) {
+                  debug('free error %s', err.message);
+                  process.exit(1);
+                }
+                var handles = process._getActiveHandles();
+                if (handles && handles.length) {
+                  debug('free warning %s active handles still open', handles.length);
+                }
+                process.exit(0);
+              });
+            }, freeAfter * 1000);
+            setTimeout(function forceKill() {
+              debug('shutdown timeout, force killed');
+              process.exit(1);
+            }, killAfter * 1000).unref();
+          });
+        });
+      });
+    }
+    next.apply(null);
+  });
+};
+
+App.prototype.free = function free(cb) {
+  this.perform('free', function (next) {
+    next(null);
+  }, cb);
 };
 
 module.exports = App;

--- a/lib/app.js
+++ b/lib/app.js
@@ -30,17 +30,23 @@ function App(root, options) {
 
 util.inherits(App, Broadway);
 
-/*
- * function hookable (name, fn)
+/**
  * Creates a "hookable" named action that
  * other plugins and parts of the app can
  * run before or after as well as add additional
  * options into.
+ *
+ * @memberof App.prototype
+ * @param {string} name name of the action that can be intercepted
+ * @param {function} action default implementation for the named action
+ * @param {function} callback callback after completing the action's lifecycle
+ * @returns {void}
+ * @api public
  */
-App.prototype.hookable = function (name, fn, callback) {
+App.prototype.hookable = function (name, action, callback) {
   var ext = {};
   this.perform(name, this, ext, function (done) {
-    fn(ext, done);
+    action(ext, done);
   }, callback);
 };
 
@@ -48,6 +54,7 @@ App.prototype.hookable = function (name, fn, callback) {
  * Registers a new Stack for the specified `opts` with this
  * instance. Returns the middleware function for executing the
  * stack with the `handler` and optional `callback`.
+ * @memberof App.prototype
  * @param {Object} opts Options for this stack.
  * @param {function} handler Middleware handler for this stack.
  * @returns {function|Object} Middleware handler or the stack created.
@@ -71,9 +78,11 @@ App.prototype.stack = function (opts, handler) {
 /**
  * Configures the specified `app` with the standard
  * "setup" and "start" interceptor flow(s).
+ * @memberof App.prototype
  * @param {App} app Slay application to bootstrap
  * @param {string} root Root directory of the application
  * @returns {undefined} No return value.
+ * @api public
  */
 App.bootstrap = function (app, root) {
 
@@ -117,55 +126,58 @@ App.bootstrap = function (app, root) {
 /**
  * Performs a graceful shutdown of `app` with the standard
  * "close" and "free" interceptor flow(s).
- * @param {App} app Slay application to bootstrap
+ * @memberof App.prototype
  * @param {function} cb Root directory of the application
  * @returns {undefined} No return value.
+ * @api public
  */
-App.prototype.dispose = function dispose(cb) {
+App.prototype.close = function close(cb) {
   var app = this;
-  var shutdown = app.config.get('dispose');
+  var closeConfig = app.config.get('close') || {};
   function forceKill() {
-    debug('dispose timeout');
-    cb(new Error('dispose timeout'));
+    debug('close timeout');
+    cb(new Error('close timeout'));
   }
-  if (shutdown) {
-    var freeAfter = typeof dispose.freeAfter === 'number' ?
-      dispose.freeAfter :
-      30;
-    // TCP default timeout is 180s
-    var killAfter = typeof dispose.killAfter === 'number' ?
-      dispose.killAfter :
-      180;
-    debug('shutdown starting, free after %d s and force kill after %d s',
-      freeAfter,
-      killAfter);
+  var freeAfter = typeof closeConfig.freeAfter === 'number' ?
+    closeConfig.freeAfter :
+    0;
+  // TCP default timeout is 180s
+  var killAfter = typeof closeConfig.killAfter === 'number' ?
+    closeConfig.killAfter :
+    Infinity;
+  debug('shutdown starting, free after %d s and force kill after %d s',
+    freeAfter,
+    killAfter);
+  if (killAfter !== Infinity) {
     setTimeout(forceKill, killAfter * 1000).unref();
-    app.perform('close', function close(next) {
-      app.close(function onclosed(err) {
+  }
+  app.perform('close', function superclose(next) {
+    Broadway.prototype.close.call(app, function superclosed(err) {
+      if (err) {
+        debug('close error %s', err.message);
+        return void cb(err);
+      }
+      return void next();
+    });
+  }, function closed() {
+    setTimeout(freeResources, freeAfter * 1000);
+    function freeResources() {
+      app.perform('free', function free(next) {
+        next();
+      }, function freed(err) {
         if (err) {
-          debug('close error %s', err.message);
+          debug('free error %s', err);
           return void cb(err);
         }
-        return void next();
+        var handles = process._getActiveHandles();
+        if (handles && handles.length) {
+          debug('free warning %s active handles still open',
+            handles.length);
+        }
+        return void cb(null);
       });
-    }, function closed() {
-      setTimeout(freeResources, freeAfter * 1000);
-      function freeResources() {
-        app.perform('free', function (err) {
-          if (err) {
-            debug('free error %s', err.message);
-            return void cb(err);
-          }
-          var handles = process._getActiveHandles();
-          if (handles && handles.length) {
-            debug('free warning %s active handles still open',
-              handles.length);
-          }
-          return void cb(null);
-        });
-      }
-    });
-  }
+    }
+  });
 };
 
 module.exports = App;

--- a/lib/app.js
+++ b/lib/app.js
@@ -94,6 +94,7 @@ App.bootstrap = function (app, root) {
   app.preboot(builtins.routers);
 
   app.after('config', function (instance, options, done) {
+    // eslint-disable-next-line no-process-env
     app.env = (app.env || app.config.get('env') || process.env.NODE_ENV).trim();
     done();
   });
@@ -111,51 +112,53 @@ App.bootstrap = function (app, root) {
       done.apply(null, arguments);
     });
   });
-
-  app.after('start', function setupGracefulShutdown(instance, options, next) {
-    var shutdown = app.config.get('shutdown');
-    if (shutdown) {
-      console.log(shutdown)
-      var freeAfter = shutdown.freeAfter || 30;
-      // TCP default timeout is 180s
-      var killAfter = shutdown.killAfter || 180;
-      process.on('SIGTERM', function stopListening() {
-        debug('shutdown starting, will free after %d s and force kill after %d s', freeAfter, killAfter);
-        app.perform('close', function stopAccepting(next) {
-          app.close(function closed(err) {
-            if (err) {
-              debug('close error %s', err.message);
-              process.exit(1);
-            }
-            setTimeout(function freeResources() {
-              app.free(function (err) {
-                if (err) {
-                  debug('free error %s', err.message);
-                  process.exit(1);
-                }
-                var handles = process._getActiveHandles();
-                if (handles && handles.length) {
-                  debug('free warning %s active handles still open', handles.length);
-                }
-                process.exit(0);
-              });
-            }, freeAfter * 1000);
-            setTimeout(function forceKill() {
-              debug('shutdown timeout, force killed');
-              process.exit(1);
-            }, killAfter * 1000).unref();
-          });
-        });
-      });
-    }
-    next.apply(null);
-  });
 };
 
-App.prototype.free = function free(cb) {
-  this.perform('free', function (next) {
-    next(null);
-  }, cb);
+App.prototype.dispose = function dispose(cb) {
+  var app = this;
+  var shutdown = app.config.get('dispose');
+  function forceKill() {
+    debug('dispose timeout');
+    cb(new Error('dispose timeout'));
+  }
+  if (shutdown) {
+    var freeAfter = typeof dispose.freeAfter === 'number' ?
+      dispose.freeAfter :
+      30;
+    // TCP default timeout is 180s
+    var killAfter = typeof dispose.killAfter === 'number' ?
+      dispose.killAfter :
+      180;
+    debug('shutdown starting, free after %d s and force kill after %d s',
+      freeAfter,
+      killAfter);
+    setTimeout(forceKill, killAfter * 1000).unref();
+    app.perform('close', function close(next) {
+      app.close(function onclosed(err) {
+        if (err) {
+          debug('close error %s', err.message);
+          return void cb(err);
+        }
+        return void next();
+      });
+    }, function closed() {
+      setTimeout(freeResources, freeAfter * 1000);
+      function freeResources() {
+        app.perform('free', function (err) {
+          if (err) {
+            debug('free error %s', err.message);
+            return void cb(err);
+          }
+          var handles = process._getActiveHandles();
+          if (handles && handles.length) {
+            debug('free warning %s active handles still open',
+              handles.length);
+          }
+          return void cb(null);
+        });
+      }
+    });
+  }
 };
 
 module.exports = App;

--- a/lib/app.js
+++ b/lib/app.js
@@ -114,6 +114,13 @@ App.bootstrap = function (app, root) {
   });
 };
 
+/**
+ * Performs a graceful shutdown of `app` with the standard
+ * "close" and "free" interceptor flow(s).
+ * @param {App} app Slay application to bootstrap
+ * @param {function} cb Root directory of the application
+ * @returns {undefined} No return value.
+ */
 App.prototype.dispose = function dispose(cb) {
   var app = this;
   var shutdown = app.config.get('dispose');

--- a/test/slay.test.js
+++ b/test/slay.test.js
@@ -1,5 +1,5 @@
+/* eslint-disable no-process-env */
 'use strict';
-
 var assert  = require('chai').assert,
     util    = require('util'),
     path    = require('path'),
@@ -34,7 +34,6 @@ describe('Slay test suite (unit tests)', function () {
     describe('Running application tests', function () {
       var App, app;
       var baseUri = 'http://localhost:8080';
-
       var previous = process.env.NODE_ENV;
       process.env.NODE_ENV = 'unique-key ';
 

--- a/test/stacks.test.js
+++ b/test/stacks.test.js
@@ -107,7 +107,7 @@ describe('Stack tests', function () {
         assert.equal(stack, stack.unshift(hook, 'unshift hook'));
         assert.equal(2, stack[property].dispatch.length);
         assert.equal(unshift[hook], stack[property].dispatch[0]);
-      })
+      });
     });
   });
 
@@ -189,5 +189,5 @@ function testStackHook(hook) {
       assert.equal(1, stack[property].dispatch.length);
       assert.equal(handler, stack[property].dispatch[0]);
     });
-  }
+  };
 }


### PR DESCRIPTION
This changes `app.close` to be implemented by `slay` and produces a standard workflow of graceful shutdown.

Documentation has been added to the readme about the exact steps.

We might move the configuration out of the `config`; I am neutral to any approach we want.