### PR TITLE
Support skipping logger creation if it is provided

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,7 @@ const gulp = require('gulp');
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
 require('godaddy-test-tools')(gulp, {
-  lint: { files: ['*.js', 'lib/**/*.js', 'test/*.js'] },
+  lint: { files: ['*.js', 'lib/**/*.js', 'test/**/*.js'] },
   istanbulReports: { dir: 'build' },
-  unitTestFiles: 'test/*.test.js'
+  unitTestFiles: 'test/**/*.test.js'
 });

--- a/lib/preboot/logger.js
+++ b/lib/preboot/logger.js
@@ -9,6 +9,11 @@ var debug = require('diagnostics')('slay:preboot:logger');
  * a winston Logger for this app instance.
  */
 module.exports = function (app, options, callback) {
+  if (app.log) {
+    debug('executed, app.log exists, skipping hookable "logger"');
+    return callback();
+  }
+
   debug('executed, perform hookable "logger"');
 
   app.hookable('logger', function (ext, done) {

--- a/test/preboot/logger.test.js
+++ b/test/preboot/logger.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const assert = require('chai').assert;
+const winston = require('winston');
+const logger = require('../../lib/preboot/logger');
+
+describe('Logger test suite (unit tests)', function () {
+
+  describe('Initialization of module', function () {
+    it('Is defined', function () {
+      assert(logger);
+      assert.typeOf(logger, 'function');
+    });
+  });
+
+  describe('Preboot', function () {
+    it('should call hookable', function (done) {
+      const prebootCallback = () => { };
+      const app = {
+        hookable: (event, fn, callback) => {
+          assert.equal(event, 'logger');
+          assert.equal(callback, prebootCallback);
+          done();
+        }
+      };
+      logger(app, null, prebootCallback);
+    });
+
+    it('should produce logger', function (done) {
+      const app = {
+        hookable: (event, fn, callback) => {
+          fn(null, () => {
+            callback();
+          });
+        },
+        after: (event, callback) => {
+          assert.equal(event, 'start');
+          assert.typeOf(callback, 'function');
+        }
+      };
+      const options = {
+        log: {
+          transports: [new winston.transports.Console()]
+        }
+      };
+      logger(app, options, () => {
+        assert(app.log);
+        assert.typeOf(app.log.error, 'function');
+        assert.typeOf(app.log.warn, 'function');
+        assert.typeOf(app.log.info, 'function');
+        done();
+      });
+    });
+
+    it('should not produce logger when app.log exists', function (done) {
+      const log = { };
+      const app = {
+        log
+      };
+      logger(app, null, () => {
+        assert.equal(app.log, log);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
The allows:
- an app to provide their own logger.
- skip the creation of the `winston` logger.
- avoid constructing `winston` transport configuration, when not used.