### PR TITLE
Expose log provider to app

### DIFF
--- a/lib/preboot/logger.js
+++ b/lib/preboot/logger.js
@@ -12,6 +12,7 @@ module.exports = function (app, options, callback) {
   debug('executed, perform hookable "logger"');
 
   app.hookable('logger', function (ext, done) {
+    app.logProvider = winston;
     app.log = winston.createLogger(merge({}, options.log, ext));
 
     //

--- a/lib/preboot/logger.js
+++ b/lib/preboot/logger.js
@@ -12,7 +12,11 @@ module.exports = function (app, options, callback) {
   debug('executed, perform hookable "logger"');
 
   app.hookable('logger', function (ext, done) {
-    app.logProvider = winston;
+    app.logProvider = {
+      transports: winston.transports,
+      formats: winston.formats,
+      Container: winston.Container
+    };
     app.log = winston.createLogger(merge({}, options.log, ext));
 
     //

--- a/test/slay.test.js
+++ b/test/slay.test.js
@@ -6,6 +6,7 @@ const util = require('util');
 const path = require('path');
 const request = require('request');
 const slay = require('../');
+const winston = require('winston');
 
 describe('Slay test suite (unit tests)', function () {
 
@@ -92,6 +93,19 @@ describe('Slay test suite (unit tests)', function () {
       /* Shutdown the app */
       after(function (done) {
         app.close(done);
+      });
+    });
+
+    describe('Preboot logger', function () {
+      it('should expose logProvider as winston', function (done) {
+        const app = new slay.App(path.join(__dirname, 'fixtures'), {
+        });
+        app.start(function (error) {
+          assert.ifError(error);
+          assert.strictEqual(app.logProvider, winston);
+
+          app.close(done);
+        });
       });
     });
 

--- a/test/slay.test.js
+++ b/test/slay.test.js
@@ -102,7 +102,9 @@ describe('Slay test suite (unit tests)', function () {
         });
         app.start(function (error) {
           assert.ifError(error);
-          assert.strictEqual(app.logProvider, winston);
+          assert.strictEqual(app.logProvider.transports, winston.transports);
+          assert.strictEqual(app.logProvider.formats, winston.formats);
+          assert.strictEqual(app.logProvider.Container, winston.Container);
 
           app.close(done);
         });


### PR DESCRIPTION
In order to configure winston transports, the application needs to install winston as a dependency. Since slay has this as a hard-coded dependency, the app and slay could reference two different versions of the winston package. By exposing winston to the app, it has the ability to reference the builtin transports without having to install it's own copy.

## sample
```javascript
  app.preboot(require('slay-log')({
    transports: [
      new (app.logProvider.transports.Console)()
    ]
  }));
```