### PR TITLE
Remove snyk dependency

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,8 +1,0 @@
-# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.14.1
-ignore: {}
-# patches apply the minimum changes required to fix a vulnerability
-patch:
-  SNYK-JS-LODASH-567746:
-    - winston > async > lodash:
-        patched: '2020-05-01T04:42:23.738Z'

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "eslint-config-godaddy": "^6.0.0",
     "mocha": "^9.2.2",
     "request": "^2.79.0",
-    "sinon": "^1.17.2",
-    "snyk": "^1.316.1"
+    "sinon": "^1.17.2"
   },
   "engines": {
     "node": ">=10.0.0"
@@ -29,8 +28,6 @@
     "lint": "eslint --fix ./lib ./test",
     "posttest": "npm run lint",
     "test": "mocha ./test/*.test.js",
-    "snyk-protect": "snyk protect",
-    "prepublishOnly": "npm run snyk-protect"
   },
   "repository": {
     "type": "git",
@@ -41,6 +38,5 @@
     "Charlie Robbins <crobbins@godaddy.com>",
     "Fady Matar <fmatar@godaddy.com>"
   ],
-  "license": "MIT",
-  "snyk": true
+  "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "express": "^4.13.3",
     "lodash.merge": "^4.6.2",
     "nconf": "^0.12.0",
-    "snyk": "^1.316.1",
     "understudy": "^4.1.0",
     "winston": "^3.1.0"
   },
@@ -20,7 +19,8 @@
     "eslint-config-godaddy": "^6.0.0",
     "mocha": "^9.2.2",
     "request": "^2.79.0",
-    "sinon": "^1.17.2"
+    "sinon": "^1.17.2",
+    "snyk": "^1.316.1"
   },
   "engines": {
     "node": ">=10.0.0"


### PR DESCRIPTION
`snyk` has a post install script that installs a `go` binary. The particular version has a vulnerability.

I did try and run `snyk protect` and it looks like it is deprecated anyway - after discussion the decision was made to remove the dependency.

```
npm run snyk-protect

> slay@4.0.0 snyk-protect
> snyk protect


⚠ WARNING: Snyk protect was removed at 31 March 2022.
Please use '@snyk/protect' package instead: https://updates.snyk.io/snyk-wizard-and-snyk-protect-removal-224137
```